### PR TITLE
Return only bytes that have been read

### DIFF
--- a/tcp.go
+++ b/tcp.go
@@ -4,7 +4,6 @@ import (
 	"net"
 
 	"go.k6.io/k6/js/modules"
-
 )
 
 func init() {
@@ -33,11 +32,11 @@ func (tcp *TCP) Write(conn net.Conn, data []byte) error {
 
 func (tcp *TCP) Read(conn net.Conn, size int) ([]byte, error) {
 	buf := make([]byte, size)
-	_, err := conn.Read(buf)
+	n, err := conn.Read(buf)
 	if err != nil {
 		return nil, err
 	}
-	return buf, nil
+	return buf[:n], nil
 }
 
 func (tcp *TCP) WriteLn(conn net.Conn, data []byte) error {


### PR DESCRIPTION
`Read` currently returns a fixed size array with 0s for bytes outside of those that have been read, which makes it difficult to reliably write logic around this that reads all expected data over time without using 0s as an indicator for it. This PR updates `Read` to truncate the returned array to only include the bytes that have been read.

This would be a breaking change in terms of expectations of existing users, so I'm not sure if you want to merge it, but opening it in case you do.